### PR TITLE
Change behavior of `.previous_market_day` on weekends

### DIFF
--- a/lib/stock_market_days/calculator.rb
+++ b/lib/stock_market_days/calculator.rb
@@ -40,12 +40,16 @@ module StockMarketDays
       if market_days_list[begin_index] == begin_day
         market_days_list[begin_index + days]
       elsif market_days_list[begin_index] > begin_day
-        market_days_list[begin_index - 1 + days]
+        if days == 0
+          market_days_list[begin_index - 1]
+        else
+          offset = days > 0 ? -1 : 0
+          market_days_list[begin_index + offset + days]
+        end
       else
         raise "Calculator Error - This shouldn't happen in StockMarketDays#market_days_from"
       end
     end
-
 
   end
 end

--- a/spec/stock_market_days/stock_market_days_spec.rb
+++ b/spec/stock_market_days/stock_market_days_spec.rb
@@ -211,4 +211,32 @@ describe StockMarketDays do
     end
   end
 
+  context '#previous_market_day' do
+    subject { described_class.previous_market_day(from_date) }
+
+    context 'on a Saturday' do
+      let(:from_date) { Date.new(2020,1,4) }
+    
+      it { is_expected.to eql(Date.new(2020,1,3)) }
+    end
+
+    context 'on Labor Day' do
+      let(:from_date) { Date.new(2019,9,2) }
+    
+      it { is_expected.to eql(Date.new(2019,8,30)) }
+    end
+
+    context 'on a regular trading day' do
+      let(:from_date) { Date.new(2019,9,5) }
+
+      it { is_expected.to eql(Date.new(2019,9,4)) }
+    end
+
+    context 'on a Monday' do
+      let(:from_date) { Date.new(2019,9,23) }
+
+      it { is_expected.to eql(Date.new(2019,9,20)) }
+    end
+  end
+
 end


### PR DESCRIPTION
`StockMarketDays::previous_market_day` on a weekend returns the previous Thursday.

I thought that Friday would be the expected return value, so I modified the behavior and added some tests.