### PR TITLE
Fixes for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ gem 'stock_market_days'
 
 ## Available Methods
 
-`is_market_day?` - tells you whether the given date is a date US markets are open
-`market_days_between` - tells number of trading days between two dates
-`market_days_from` - gives you the trading day of given date, plus number of trading days 
+* `is_market_day?` - tells you whether the given date is a date US markets are open
+* `market_days_between` - tells number of trading days between two dates
+* `market_days_from` - gives you the trading day of given date, plus number of trading days 
 
 
 Look at the test suite for examples of usage.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Typically, markets are closed on weekends and the following holidays:
 * New Year's Day (January 1st, or first Monday of January if on weekend)
 * Martin Luther King Day (third Monday of January)
 * Washington's Birthday (third Monday of Feburary)
-* Good Friday (Determined by http://www.maa.clell.de/StarDate/publ_holidays.html)
+* Good Friday (Determined by [https://spider.seds.org/spider/ScholarX/publ_holidays.html](https://spider.seds.org/spider/ScholarX/publ_holidays.html))
 * Memorial Day (last Monday of May)
 * Juneteenth (June 19, or nearest Monday or Friday if on a weekend)
 * Independence Day (July 4, or July 3rd if on Saturday, July 5th if on Sunday)


### PR DESCRIPTION
The Easter dates reference page ([archive link](https://web.archive.org/web/20200224050020/http://www.maa.clell.de/StarDate/publ_holidays.html)) went down, so I pointed it [here](https://spider.seds.org/spider/ScholarX/publ_holidays.html).